### PR TITLE
Use ISO 8601 as datetime format

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -58,19 +58,7 @@ def maps():
     return jsonify([m.to_dict() for m in Map.all()])
 
 
-def _parse_datetime(_datetime):
-    if not _datetime:
-        _datetime = datetime.now()
-    if 'date' in request.json:
-        _date = datetime.strptime(request.json['date'], '%Y-%m-%d')
-        _datetime.replace(year=_date.year, month=_date.month, day=_date.day)
-    if 'time' in request.json:
-        _time = datetime.strptime(request.json['time'], '%H:%M')
-        _datetime.replace(hour=_time.hour, minute=_time.minute)
-    if 'datetime' in request.json:
-        _datetime = datetime.strptime(request.json['datetime'], '%Y-%m-%d %H:%M')
 
-    return _datetime
 
 @api.route('/api/maps/', methods=['POST'])
 @api.route('/api/maps', methods=['POST'])
@@ -90,7 +78,7 @@ def maps_new():
             setattr(m, key, json[key])
 
     if 'datetime' in json:
-        m.datetime = _parse_datetime()
+        m.datetime = datetime.fromisoformat(request.json['datetime'])
 
     db.session.add(m)
     db.session.commit()
@@ -129,7 +117,7 @@ def map_edit(map_id):
                 setattr(m, key, json[key])
 
     if 'datetime' in json:
-        m.datetime = _parse_datetime(m.datetime)
+        m.datetime = datetime.fromisoformat(request.json['datetime'])
 
     db.session.add(m)
     db.session.commit()

--- a/app/mapnik.py
+++ b/app/mapnik.py
@@ -8,6 +8,7 @@ from flask import current_app
 from geojson import FeatureCollection, Feature, Point
 from timeit import default_timer as timer
 from app.utils import get_xml, strip
+from datetime import datetime, timezone
 
 
 register_fonts('/usr/share/fonts')
@@ -62,16 +63,17 @@ class MapRenderer:
         print("Map.init - Map: ", end - mid)
         print("Map.init - Total: ", end - start)
 
-    def _add_legend(self, name, place, datetime, attributes):
+    def _add_legend(self, name, place, date, attributes):
         features = []
         box = self._map.envelope()
 
         # add name, place and date
         point = Point((box.minx, box.maxy))
+        _date = datetime.fromisoformat(date)
         features.append(Feature(geometry=point, properties={
             'name': name,
             'place': place,
-            'date': datetime#strftime('%d.%m.%Y %H:%M')
+            'date': _date.strftime('%d.%m.%Y %H:%M')
             }))
 
         # add properties

--- a/app/models.py
+++ b/app/models.py
@@ -143,7 +143,7 @@ class Map(db.Model):
             'id': self.uuid.hex,
             'name': self.name,
             'description': self.description,
-            'datetime': self.datetime.strftime('%Y-%m-%d %H:%M'),
+            'datetime': self.datetime.astimezone().isoformat(),
             'attributes': self.attributes if self.attributes else [],
             'bbox': self.bbox,
             'place': self.place,


### PR DESCRIPTION
Only support dates in a defined way. For that use ISO 8601 standard (as it supports timezones as well). 

Note: At least python 3.6 is required.