### PR TITLE
Feature/description pdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libcairo2-dev
       - postgresql-10-postgis-2.4
       - osm2pgsql
+      - fonts-noto
 before_install:
   - python --version
   - pip install -U pip

--- a/app/mapnik.py
+++ b/app/mapnik.py
@@ -9,6 +9,9 @@ from geojson import FeatureCollection, Feature, Point
 from timeit import default_timer as timer
 from app.utils import datetime_fromisoformat, get_xml, strip
 from datetime import datetime, timezone
+from fpdf import FPDF
+from PyPDF2 import PdfFileReader, PdfFileWriter
+
 
 register_fonts('/usr/share/fonts')
 
@@ -116,8 +119,6 @@ class MapRenderer:
         load_map_from_string(self._map, xml_str)
 
     def _create_description_pdf(self):
-          from fpdf import FPDF
-
           pdf = FPDF()
           pdf.add_page()
           pdf.set_font('Arial', size=12)
@@ -206,9 +207,6 @@ class MapRenderer:
 
         # add description as second page if pdf
         if mimetype == 'application/pdf' and len(self._description) > 0:
-          from PyPDF2 import PdfFileReader, PdfFileWriter
-
-          # Merge both PDFs
           writer = PdfFileWriter()
 
           map_reader = PdfFileReader(f)

--- a/app/mapnik.py
+++ b/app/mapnik.py
@@ -15,6 +15,7 @@ from PyPDF2 import PdfFileReader, PdfFileWriter
 
 register_fonts('/usr/share/fonts/TTF')
 register_fonts('/usr/share/fonts/noto')
+register_fonts('/usr/share/fonts/truetype/noto/') # ubuntu noto dir
 
 
 class MapRenderer:

--- a/app/mapnik.py
+++ b/app/mapnik.py
@@ -13,7 +13,8 @@ from fpdf import FPDF
 from PyPDF2 import PdfFileReader, PdfFileWriter
 
 
-register_fonts('/usr/share/fonts')
+register_fonts('/usr/share/fonts/TTF')
+register_fonts('/usr/share/fonts/noto')
 
 
 class MapRenderer:

--- a/app/mapnik.py
+++ b/app/mapnik.py
@@ -206,7 +206,7 @@ class MapRenderer:
         f.seek(0)
 
         # add description as second page if pdf
-        if mimetype == 'application/pdf' and len(self._description) > 0:
+        if mimetype == 'application/pdf' and self._description:
           writer = PdfFileWriter()
 
           map_reader = PdfFileReader(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ gunicorn
 Flask-Migrate
 backports-datetime-fromisoformat; python_version < '3.7'
 wand
+fpdf
+pypdf2


### PR DESCRIPTION
According to the map creation wizard of our frontend, the description provided for a map is supposed to be rendered as a backside of the pdf map (second page). This is currently not the case.

A way to add support for this, is with the help of fpdf and pypdf2. Unfortunately, we need to be able to create pdfs with long (multi paragraph) texts and be able to merge pdfs. Hence, both both libs are needed.